### PR TITLE
Add di to home screen

### DIFF
--- a/app/src/androidTest/java/com/alex/mapnotes/TestAppModule.kt
+++ b/app/src/androidTest/java/com/alex/mapnotes/TestAppModule.kt
@@ -44,4 +44,6 @@ val testAppModule = applicationContext {
     factory { SearchNotesPresenter(get(), get(), get()) as SearchNotesMvpPresenter }
 
     factory { GoogleMapPresenter() as MapMvpPresenter }
+
+    factory { HomePresenter(get(), get()) as HomeMvpPresenter }
 }

--- a/app/src/androidTest/java/com/alex/mapnotes/TestAppModule.kt
+++ b/app/src/androidTest/java/com/alex/mapnotes/TestAppModule.kt
@@ -44,6 +44,4 @@ val testAppModule = applicationContext {
     factory { SearchNotesPresenter(get(), get(), get()) as SearchNotesMvpPresenter }
 
     factory { GoogleMapPresenter() as MapMvpPresenter }
-
-    factory { HomePresenter(get(), get()) as HomeMvpPresenter }
 }

--- a/app/src/androidTest/java/com/alex/mapnotes/home/HomeActivityTest.kt
+++ b/app/src/androidTest/java/com/alex/mapnotes/home/HomeActivityTest.kt
@@ -1,10 +1,14 @@
 package com.alex.mapnotes.home
 
 import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import android.support.test.espresso.action.ViewActions.click
 import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.intent.Intents
+import android.support.test.espresso.intent.matcher.IntentMatchers
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withHint
+import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
 import android.support.test.espresso.matcher.ViewMatchers.isEnabled
 import android.support.test.rule.ActivityTestRule
@@ -13,6 +17,7 @@ import android.support.test.runner.AndroidJUnit4
 import com.alex.mapnotes.MockMapNotesApp
 import com.alex.mapnotes.R
 import com.alex.mapnotes.data.Result
+import com.alex.mapnotes.login.LoginActivity
 import com.alex.mapnotes.matchers.BottomNavigationViewMatchers.hasItemTitle
 import com.alex.mapnotes.matchers.BottomNavigationViewMatchers.withItemCount
 import com.alex.mapnotes.matchers.BottomNavigationViewMatchers.hasCheckedItem
@@ -101,6 +106,18 @@ class HomeActivityTest {
                 .perform(click())
         onView(withId(R.id.navigation))
                 .check(matches(hasCheckedItem(R.id.navigation_map)))
+    }
+
+    @Test
+    fun shouldVerifySignOut() {
+        coEvery { MockMapNotesApp.mockedUserRepository.signOut() } answers { nothing }
+
+        Intents.init()
+        openActionBarOverflowOrOptionsMenu(activityRule.activity)
+        onView(withText(R.string.nav_sign_out_title))
+                .perform(click())
+        Intents.intended(IntentMatchers.hasComponent(LoginActivity::class.java.name))
+        Intents.release()
     }
 
     private fun getStr(resId: Int): String {

--- a/app/src/androidTest/java/com/alex/mapnotes/home/HomeActivityTest.kt
+++ b/app/src/androidTest/java/com/alex/mapnotes/home/HomeActivityTest.kt
@@ -1,0 +1,69 @@
+package com.alex.mapnotes.home
+
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.rule.ActivityTestRule
+import android.support.test.rule.GrantPermissionRule
+import android.support.test.runner.AndroidJUnit4
+import com.alex.mapnotes.MockMapNotesApp
+import com.alex.mapnotes.R
+import com.alex.mapnotes.data.Result
+import com.alex.mapnotes.matchers.BottomNavigationViewMatchers.hasItemTitle
+import com.alex.mapnotes.matchers.BottomNavigationViewMatchers.withItemCount
+import com.alex.mapnotes.matchers.BottomNavigationViewMatchers.hasCheckedItem
+import com.alex.mapnotes.model.AuthUser
+import com.alex.mapnotes.testAppModule
+import io.mockk.coEvery
+import io.mockk.every
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.standalone.StandAloneContext.closeKoin
+import org.koin.standalone.StandAloneContext.loadKoinModules
+
+@RunWith(AndroidJUnit4::class)
+class HomeActivityTest {
+
+    @Rule @JvmField
+    val activityRule = ActivityTestRule<HomeActivity>(HomeActivity::class.java, true, false)
+
+    @Rule @JvmField
+    val permissionRule: GrantPermissionRule = GrantPermissionRule.grant(android.Manifest.permission.ACCESS_FINE_LOCATION)
+
+    @Before
+    fun setUp() {
+        loadKoinModules(listOf(testAppModule))
+        every { MockMapNotesApp.mockedLocationProvider.startLocationUpdates() } answers { nothing }
+        every { MockMapNotesApp.mockedLocationProvider.stopLocationUpdates() } answers { nothing }
+        every { MockMapNotesApp.mockedLocationProvider.addUpdatableLocationListener(any()) } answers { nothing }
+        every { MockMapNotesApp.mockedLocationProvider.isLocationAvailable() } returns true
+        coEvery { MockMapNotesApp.mockedUserRepository.getCurrentUser() } returns Result.Success(AuthUser("1111111"))
+
+        activityRule.launchActivity(null)
+    }
+
+    @Test
+    fun shouldVerifyAllTabs() {
+        onView(withId(R.id.navigation))
+                .check(matches(withItemCount(3)))
+                .check(matches(hasItemTitle(getStr(R.string.nav_add_note_title))))
+                .check(matches(hasItemTitle(getStr(R.string.nav_map_title))))
+                .check(matches(hasItemTitle(getStr(R.string.nav_search_notes_title))))
+    }
+
+    @Test
+    fun shouldVerifyMapTabCheckedByDefault() {
+        onView(withId(R.id.navigation))
+                .check(matches(hasCheckedItem(R.id.navigation_map)))
+    }
+
+    private fun getStr(resId: Int): String {
+        return activityRule.activity.getString(resId)
+    }
+
+    @After
+    fun tearDown() = closeKoin()
+}

--- a/app/src/androidTest/java/com/alex/mapnotes/home/HomeActivityTest.kt
+++ b/app/src/androidTest/java/com/alex/mapnotes/home/HomeActivityTest.kt
@@ -1,8 +1,12 @@
 package com.alex.mapnotes.home
 
 import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.action.ViewActions.click
 import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.espresso.matcher.ViewMatchers.withHint
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
+import android.support.test.espresso.matcher.ViewMatchers.isEnabled
 import android.support.test.rule.ActivityTestRule
 import android.support.test.rule.GrantPermissionRule
 import android.support.test.runner.AndroidJUnit4
@@ -16,6 +20,7 @@ import com.alex.mapnotes.model.AuthUser
 import com.alex.mapnotes.testAppModule
 import io.mockk.coEvery
 import io.mockk.every
+import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -56,6 +61,44 @@ class HomeActivityTest {
 
     @Test
     fun shouldVerifyMapTabCheckedByDefault() {
+        onView(withId(R.id.navigation))
+                .check(matches(hasCheckedItem(R.id.navigation_map)))
+    }
+
+    @Test
+    fun shouldVerifyAddNoteFragment() {
+        onView(withId(R.id.navigation_add_note))
+                .perform(click())
+        onView(withId(R.id.navigation))
+                .check(matches(hasCheckedItem(R.id.navigation_add_note)))
+        onView(withHint(R.string.add_note_hint))
+                .check(matches(isDisplayed()))
+        onView(withId(R.id.add))
+                .check(matches(not(isEnabled())))
+    }
+
+    @Test
+    fun shouldVerifySearchNoteFragment() {
+        coEvery { MockMapNotesApp.mockedNotesRepository.getNotes(any()) } returns Result.Success(listOf())
+
+        onView(withId(R.id.navigation_search_notes))
+                .perform(click())
+        onView(withId(R.id.navigation))
+                .check(matches(hasCheckedItem(R.id.navigation_search_notes)))
+        onView(withHint(R.string.search_hint))
+                .check(matches(isDisplayed()))
+        onView(withId(R.id.searchButton))
+                .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun shouldVerifyMapFragmentAfterMovingFromAddTab() {
+        onView(withId(R.id.navigation_add_note))
+                .perform(click())
+        onView(withId(R.id.navigation))
+                .check(matches(hasCheckedItem(R.id.navigation_add_note)))
+        onView(withId(R.id.navigation_map))
+                .perform(click())
         onView(withId(R.id.navigation))
                 .check(matches(hasCheckedItem(R.id.navigation_map)))
     }

--- a/app/src/androidTest/java/com/alex/mapnotes/login/SignInActivityTest.kt
+++ b/app/src/androidTest/java/com/alex/mapnotes/login/SignInActivityTest.kt
@@ -102,11 +102,13 @@ class SignInActivityTest {
     @Test
     fun shouldOpenMapScreenAfterSuccessfulSignIn() {
         Intents.init()
+        val authUser = AuthUser("111111")
         every { MockMapNotesApp.mockedLocationProvider.startLocationUpdates() } answers { nothing }
         every { MockMapNotesApp.mockedLocationProvider.stopLocationUpdates() } answers { nothing }
         every { MockMapNotesApp.mockedLocationProvider.addUpdatableLocationListener(any()) } answers { nothing }
         every { MockMapNotesApp.mockedLocationProvider.isLocationAvailable() } returns false
-        coEvery { MockMapNotesApp.mockedUserRepository.signIn(correctEmail, password) } returns Result.Success(AuthUser("111111"))
+        coEvery { MockMapNotesApp.mockedUserRepository.signIn(correctEmail, password) } returns Result.Success(authUser)
+        coEvery { MockMapNotesApp.mockedUserRepository.getCurrentUser() } returns Result.Success(authUser)
 
         onView(withId(R.id.email))
                 .perform(replaceText(correctEmail))

--- a/app/src/androidTest/java/com/alex/mapnotes/login/SignUpActivityTest.kt
+++ b/app/src/androidTest/java/com/alex/mapnotes/login/SignUpActivityTest.kt
@@ -128,6 +128,7 @@ class SignUpActivityTest {
         every { MockMapNotesApp.mockedLocationProvider.isLocationAvailable() } returns false
         coEvery { MockMapNotesApp.mockedUserRepository.changeUserName(authUser, username) } answers { nothing }
         coEvery { MockMapNotesApp.mockedUserRepository.signUp(correctEmail, password) } returns Result.Success(authUser)
+        coEvery { MockMapNotesApp.mockedUserRepository.getCurrentUser() } returns Result.Success(authUser)
 
         onView(withId(R.id.name))
                 .perform(replaceText(username))

--- a/app/src/androidTest/java/com/alex/mapnotes/matchers/BottomNavigationViewMatchers.kt
+++ b/app/src/androidTest/java/com/alex/mapnotes/matchers/BottomNavigationViewMatchers.kt
@@ -1,0 +1,64 @@
+package com.alex.mapnotes.matchers
+
+import android.support.design.widget.BottomNavigationView
+import android.view.View
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
+
+object BottomNavigationViewMatchers {
+
+    fun hasCheckedItem(itemId: Int): Matcher<View> {
+        return object : TypeSafeMatcher<View>() {
+            override fun matchesSafely(view: View): Boolean {
+                val bottomNavigationView = view as BottomNavigationView
+                val menu = bottomNavigationView.menu
+                for (i in 0 until menu.size()) {
+                    val item = menu.getItem(i)
+                    if (item.isChecked) {
+                        return item.itemId == itemId
+                    }
+                }
+                return false
+            }
+
+            override fun describeTo(description: Description) {
+                description.appendText("BottomNavigationView should have checked item with id: $itemId")
+            }
+        }
+    }
+
+    fun withItemCount(count: Int): Matcher<View> {
+        return object : TypeSafeMatcher<View>() {
+            override fun matchesSafely(view: View): Boolean {
+                val bottomNavigationView = view as BottomNavigationView
+                val menu = bottomNavigationView.menu
+                return menu.size() == count
+            }
+
+            override fun describeTo(description: Description) {
+                description.appendText("BottomNavigationView should have $count item")
+            }
+        }
+    }
+
+    fun hasItemTitle(text: String): Matcher<View> {
+        return object : TypeSafeMatcher<View>() {
+            override fun matchesSafely(view: View): Boolean {
+                val bottomNavigationView = view as BottomNavigationView
+                val menu = bottomNavigationView.menu
+                for (i in 0 until menu.size()) {
+                    val item = menu.getItem(i)
+                    if (item.title.contains(text)) {
+                        return true
+                    }
+                }
+                return false
+            }
+
+            override fun describeTo(description: Description) {
+                description.appendText("BottomNavigationView should have item with text: $text")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/alex/mapnotes/di/AppModule.kt
+++ b/app/src/main/java/com/alex/mapnotes/di/AppModule.kt
@@ -12,6 +12,8 @@ import com.alex.mapnotes.data.repository.FirebaseNotesRepository
 import com.alex.mapnotes.data.repository.FirebaseUserRepository
 import com.alex.mapnotes.data.repository.NotesRepository
 import com.alex.mapnotes.data.repository.UserRepository
+import com.alex.mapnotes.home.HomeMvpPresenter
+import com.alex.mapnotes.home.HomePresenter
 import com.alex.mapnotes.login.signin.SignInMvpPresenter
 import com.alex.mapnotes.login.signin.SignInPresenter
 import com.alex.mapnotes.login.signup.SignUpMvpPresenter
@@ -51,6 +53,9 @@ val appModule = applicationContext {
 
     // Map
     factory { GoogleMapPresenter() as MapMvpPresenter }
+
+    // Home
+    factory { HomePresenter(get(), get()) as HomeMvpPresenter }
 }
 
 object Properties {

--- a/app/src/main/java/com/alex/mapnotes/home/HomeActivity.kt
+++ b/app/src/main/java/com/alex/mapnotes/home/HomeActivity.kt
@@ -17,12 +17,8 @@ import android.support.v7.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
-import com.alex.mapnotes.AppExecutors
-import com.alex.mapnotes.nopermissions.NoLocationPermissionFragment
 import com.alex.mapnotes.R
 import com.alex.mapnotes.add.AddNoteFragment
-import com.alex.mapnotes.data.repository.FirebaseUserRepository
-import com.alex.mapnotes.data.repository.UserRepository
 import com.alex.mapnotes.ext.LOCATION_REQUEST_CODE
 import com.alex.mapnotes.ext.checkLocationPermission
 import com.alex.mapnotes.ext.navigateTo
@@ -30,9 +26,11 @@ import com.alex.mapnotes.ext.requestLocationPermissions
 import com.alex.mapnotes.login.LoginActivity
 import com.alex.mapnotes.map.GoogleMapFragment
 import com.alex.mapnotes.model.Note
+import com.alex.mapnotes.nopermissions.NoLocationPermissionFragment
 import com.alex.mapnotes.search.SearchNotesFragment
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.button_sheet.*
+import org.koin.android.ext.android.inject
 
 const val DISPLAY_LOCATION = "display_location"
 const val EXTRA_NOTE = "note"
@@ -40,9 +38,8 @@ const val EXTRA_NOTE = "note"
 class HomeActivity : AppCompatActivity(), HomeView {
     private var mapFragment: GoogleMapFragment? = null
     private val bottomSheetBehavior by lazy { BottomSheetBehavior.from(bottomSheet) }
-    private val appExecutors: AppExecutors by lazy { AppExecutors() }
-    private val userRepository: UserRepository by lazy { FirebaseUserRepository(appExecutors) }
-    private val presenter: HomeMvpPresenter by lazy { HomePresenter(appExecutors, userRepository) }
+
+    private val presenter: HomeMvpPresenter by inject()
 
     private val hideExpandedMenuListener = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {

--- a/app/src/main/java/com/alex/mapnotes/home/HomePresenter.kt
+++ b/app/src/main/java/com/alex/mapnotes/home/HomePresenter.kt
@@ -19,22 +19,25 @@ class HomePresenter(
     }
 
     override fun handleNavigationItemClick(itemId: Int): Boolean {
-        when (itemId) {
-            R.id.navigation_add_note -> {
-                view?.updateMapInteractionMode(true)
-                view?.displayAddNote()
-                view?.updateNavigationState(BottomSheetBehavior.STATE_COLLAPSED)
-                return true
-            }
-            R.id.navigation_map -> {
-                view?.updateNavigationState(BottomSheetBehavior.STATE_HIDDEN)
-                return true
-            }
-            R.id.navigation_search_notes -> {
-                view?.updateMapInteractionMode(true)
-                view?.displaySearchNotes()
-                view?.updateNavigationState(BottomSheetBehavior.STATE_EXPANDED)
-                return true
+        view?.let { view ->
+            when (itemId) {
+                R.id.navigation_add_note -> {
+                    view.updateMapInteractionMode(true)
+                    view.displayAddNote()
+                    view.updateNavigationState(BottomSheetBehavior.STATE_COLLAPSED)
+                    return true
+                }
+                R.id.navigation_map -> {
+                    view.updateNavigationState(BottomSheetBehavior.STATE_HIDDEN)
+                    return true
+                }
+                R.id.navigation_search_notes -> {
+                    view.updateMapInteractionMode(true)
+                    view.displaySearchNotes()
+                    view.updateNavigationState(BottomSheetBehavior.STATE_EXPANDED)
+                    return true
+                }
+                else -> throw IllegalArgumentException("Unknown itemId")
             }
         }
         return false

--- a/app/src/main/java/com/alex/mapnotes/home/HomePresenter.kt
+++ b/app/src/main/java/com/alex/mapnotes/home/HomePresenter.kt
@@ -6,6 +6,7 @@ import com.alex.mapnotes.R
 import com.alex.mapnotes.data.Result
 import com.alex.mapnotes.data.repository.UserRepository
 import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.withContext
 
 class HomePresenter(
     private val appExecutors: AppExecutors,
@@ -64,14 +65,15 @@ class HomePresenter(
     }
 
     override fun signOut() {
-        launch(appExecutors.uiContext) {
-            launch(appExecutors.ioContext) {
-                userRepository.signOut()
-            }.join()
-            view?.navigateToLoginScreen()
+        view?.let { view ->
+            launch(appExecutors.uiContext) {
+                withContext(appExecutors.ioContext) {
+                    userRepository.signOut()
+                }
+                view.navigateToLoginScreen()
+            }
         }
     }
-
     override fun onDetach() {
         this.view = null
     }

--- a/app/src/main/java/com/alex/mapnotes/home/HomePresenter.kt
+++ b/app/src/main/java/com/alex/mapnotes/home/HomePresenter.kt
@@ -51,7 +51,7 @@ class HomePresenter(
     }
 
     override fun checkUser() {
-        view?.let {view ->
+        view?.let { view ->
             launch(appExecutors.uiContext) {
                 val currentUser = userRepository.getCurrentUser()
                 when (currentUser) {

--- a/app/src/main/java/com/alex/mapnotes/home/HomePresenter.kt
+++ b/app/src/main/java/com/alex/mapnotes/home/HomePresenter.kt
@@ -51,11 +51,13 @@ class HomePresenter(
     }
 
     override fun checkUser() {
-        launch(appExecutors.uiContext) {
-            val currentUser = userRepository.getCurrentUser()
-            when (currentUser) {
-                is Result.Error -> {
-                    view?.navigateToLoginScreen()
+        view?.let {view ->
+            launch(appExecutors.uiContext) {
+                val currentUser = userRepository.getCurrentUser()
+                when (currentUser) {
+                    is Result.Error -> {
+                        view.navigateToLoginScreen()
+                    }
                 }
             }
         }

--- a/app/src/test/java/com/alex/mapnotes/home/HomePresenterTest.kt
+++ b/app/src/test/java/com/alex/mapnotes/home/HomePresenterTest.kt
@@ -11,6 +11,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.coVerify
 import kotlinx.coroutines.experimental.android.UI
 import org.junit.After
 import org.junit.Assert.assertFalse
@@ -137,6 +138,20 @@ class HomePresenterTest {
         verify { view.navigateToLoginScreen() }
     }
 
+    @Test
+    fun `verify signOut when non-null view is attached`() {
+        every { view.navigateToLoginScreen() } answers { nothing }
+        every { appExecutors.uiContext } returns UI
+        every { appExecutors.ioContext } returns UI
+        coEvery { userRepository.signOut() } answers { nothing }
+
+        presenter.onAttach(view)
+        presenter.signOut()
+
+        coVerify { userRepository.signOut() }
+        verify { view.navigateToLoginScreen() }
+    }
+
     // null view
 
     @Test
@@ -215,6 +230,20 @@ class HomePresenterTest {
         presenter.onAttach(null)
         presenter.checkUser()
 
+        verify(exactly = 0) { view.navigateToLoginScreen() }
+    }
+
+    @Test
+    fun `verify signOut when null view is attached`() {
+        every { view.navigateToLoginScreen() } answers { nothing }
+        every { appExecutors.uiContext } returns UI
+        every { appExecutors.ioContext } returns UI
+        coEvery { userRepository.signOut() } answers { nothing }
+
+        presenter.onAttach(null)
+        presenter.signOut()
+
+        coVerify(exactly = 0) { userRepository.signOut() }
         verify(exactly = 0) { view.navigateToLoginScreen() }
     }
 
@@ -303,6 +332,21 @@ class HomePresenterTest {
         presenter.onDetach()
         presenter.checkUser()
 
+        verify(exactly = 0) { view.navigateToLoginScreen() }
+    }
+
+    @Test
+    fun `verify signOut when view is detached`() {
+        every { view.navigateToLoginScreen() } answers { nothing }
+        every { appExecutors.uiContext } returns UI
+        every { appExecutors.ioContext } returns UI
+        coEvery { userRepository.signOut() } answers { nothing }
+
+        presenter.onAttach(view)
+        presenter.onDetach()
+        presenter.signOut()
+
+        coVerify(exactly = 0) { userRepository.signOut() }
         verify(exactly = 0) { view.navigateToLoginScreen() }
     }
 

--- a/app/src/test/java/com/alex/mapnotes/home/HomePresenterTest.kt
+++ b/app/src/test/java/com/alex/mapnotes/home/HomePresenterTest.kt
@@ -98,6 +98,18 @@ class HomePresenterTest {
         verify(exactly = 0) { view.updateMapInteractionMode(any()) }
     }
 
+    @Test
+    fun `verify showLocationPermissionRationale when non-null view is attached`() {
+        every { view.showPermissionExplanationSnackBar() } answers { nothing }
+        every { view.hideContentWhichRequirePermissions() } answers { nothing }
+
+        presenter.onAttach(view)
+        presenter.showLocationPermissionRationale()
+
+        verify { view.showPermissionExplanationSnackBar() }
+        verify { view.hideContentWhichRequirePermissions() }
+    }
+
     // null view
 
     @Test
@@ -146,6 +158,15 @@ class HomePresenterTest {
         verify(exactly = 0) { view.displayAddNote() }
         verify(exactly = 0) { view.displaySearchNotes() }
         verify(exactly = 0) { view.updateMapInteractionMode(any()) }
+    }
+
+    @Test
+    fun `verify showLocationPermissionRationale when null view is attached`() {
+        presenter.onAttach(null)
+        presenter.showLocationPermissionRationale()
+
+        verify(exactly = 0) { view.showPermissionExplanationSnackBar() }
+        verify(exactly = 0) { view.showContentWhichRequirePermissions() }
     }
 
     // view is detached
@@ -200,6 +221,16 @@ class HomePresenterTest {
         verify(exactly = 0) { view.displayAddNote() }
         verify(exactly = 0) { view.displaySearchNotes() }
         verify(exactly = 0) { view.updateMapInteractionMode(any()) }
+    }
+
+    @Test
+    fun `verify showLocationPermissionRationale when view is detached`() {
+        presenter.onAttach(view)
+        presenter.onDetach()
+        presenter.showLocationPermissionRationale()
+
+        verify(exactly = 0) { view.showPermissionExplanationSnackBar() }
+        verify(exactly = 0) { view.showContentWhichRequirePermissions() }
     }
 
     @After

--- a/app/src/test/java/com/alex/mapnotes/home/HomePresenterTest.kt
+++ b/app/src/test/java/com/alex/mapnotes/home/HomePresenterTest.kt
@@ -3,11 +3,15 @@ package com.alex.mapnotes.home
 import android.support.design.widget.BottomSheetBehavior
 import com.alex.mapnotes.AppExecutors
 import com.alex.mapnotes.R
+import com.alex.mapnotes.data.Result
 import com.alex.mapnotes.data.repository.UserRepository
 import com.alex.mapnotes.di.appModule
+import com.alex.mapnotes.model.AuthUser
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.experimental.android.UI
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -110,6 +114,29 @@ class HomePresenterTest {
         verify { view.hideContentWhichRequirePermissions() }
     }
 
+    @Test
+    fun `verify checkUser when non-null view is attached and repository returns success`() {
+        every { appExecutors.uiContext } returns UI
+        coEvery { userRepository.getCurrentUser() } returns Result.Success(AuthUser("1111111"))
+
+        presenter.onAttach(view)
+        presenter.checkUser()
+
+        verify(exactly = 0) { view.navigateToLoginScreen() }
+    }
+
+    @Test
+    fun `verify checkUser when non-null view is attached and repository returns error`() {
+        every { view.navigateToLoginScreen() } answers { nothing }
+        every { appExecutors.uiContext } returns UI
+        coEvery { userRepository.getCurrentUser() } returns Result.Error(RuntimeException())
+
+        presenter.onAttach(view)
+        presenter.checkUser()
+
+        verify { view.navigateToLoginScreen() }
+    }
+
     // null view
 
     @Test
@@ -167,6 +194,28 @@ class HomePresenterTest {
 
         verify(exactly = 0) { view.showPermissionExplanationSnackBar() }
         verify(exactly = 0) { view.showContentWhichRequirePermissions() }
+    }
+
+    @Test
+    fun `verify checkUser when null view is attached and repository returns success`() {
+        every { appExecutors.uiContext } returns UI
+        coEvery { userRepository.getCurrentUser() } returns Result.Success(AuthUser("1111111"))
+
+        presenter.onAttach(null)
+        presenter.checkUser()
+
+        verify(exactly = 0) { view.navigateToLoginScreen() }
+    }
+
+    @Test
+    fun `verify checkUser when null view is attached and repository returns error`() {
+        every { appExecutors.uiContext } returns UI
+        coEvery { userRepository.getCurrentUser() } returns Result.Error(RuntimeException())
+
+        presenter.onAttach(null)
+        presenter.checkUser()
+
+        verify(exactly = 0) { view.navigateToLoginScreen() }
     }
 
     // view is detached
@@ -231,6 +280,30 @@ class HomePresenterTest {
 
         verify(exactly = 0) { view.showPermissionExplanationSnackBar() }
         verify(exactly = 0) { view.showContentWhichRequirePermissions() }
+    }
+
+    @Test
+    fun `verify checkUser when view is detached and repository returns success`() {
+        every { appExecutors.uiContext } returns UI
+        coEvery { userRepository.getCurrentUser() } returns Result.Success(AuthUser("1111111"))
+
+        presenter.onAttach(view)
+        presenter.onDetach()
+        presenter.checkUser()
+
+        verify(exactly = 0) { view.navigateToLoginScreen() }
+    }
+
+    @Test
+    fun `verify checkUser when view is detached and repository returns error`() {
+        every { appExecutors.uiContext } returns UI
+        coEvery { userRepository.getCurrentUser() } returns Result.Error(RuntimeException())
+
+        presenter.onAttach(view)
+        presenter.onDetach()
+        presenter.checkUser()
+
+        verify(exactly = 0) { view.navigateToLoginScreen() }
     }
 
     @After

--- a/app/src/test/java/com/alex/mapnotes/home/HomePresenterTest.kt
+++ b/app/src/test/java/com/alex/mapnotes/home/HomePresenterTest.kt
@@ -1,0 +1,207 @@
+package com.alex.mapnotes.home
+
+import android.support.design.widget.BottomSheetBehavior
+import com.alex.mapnotes.AppExecutors
+import com.alex.mapnotes.R
+import com.alex.mapnotes.data.repository.UserRepository
+import com.alex.mapnotes.di.appModule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import org.junit.runner.RunWith
+import org.koin.standalone.StandAloneContext.closeKoin
+import org.koin.standalone.StandAloneContext.loadKoinModules
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HomePresenterTest {
+    private val addItemId = R.id.navigation_add_note
+    private val mapItemId = R.id.navigation_map
+    private val searchItemId = R.id.navigation_search_notes
+    private val incorrectItemId = -1
+
+    private val appExecutors: AppExecutors = mockk()
+    private val userRepository: UserRepository = mockk()
+    private val view: HomeView = mockk()
+
+    private val presenter by lazy { HomePresenter(appExecutors, userRepository) }
+
+    @Rule @JvmField
+    val expectedException: ExpectedException = ExpectedException.none()
+
+    // non-null is attached
+
+    @Before
+    fun setUp() {
+        loadKoinModules(listOf(appModule))
+    }
+
+    @Test
+    fun `verify handleNavigationItemClick when non-null view is attached and itemId is add`() {
+        every { view.updateMapInteractionMode(true) } answers { nothing }
+        every { view.displayAddNote() } answers { nothing }
+        every { view.updateNavigationState(BottomSheetBehavior.STATE_COLLAPSED) } answers { nothing }
+
+        presenter.onAttach(view)
+        val result = presenter.handleNavigationItemClick(addItemId)
+
+        assertTrue(result)
+        verify { view.updateMapInteractionMode(true) }
+        verify { view.displayAddNote() }
+        verify { view.updateNavigationState(BottomSheetBehavior.STATE_COLLAPSED) }
+    }
+
+    @Test
+    fun `verify handleNavigationItemClick when non-null view is attached and itemId is map`() {
+        every { view.updateNavigationState(BottomSheetBehavior.STATE_HIDDEN) } answers { nothing }
+
+        presenter.onAttach(view)
+        val result = presenter.handleNavigationItemClick(mapItemId)
+
+        assertTrue(result)
+        verify { view.updateNavigationState(BottomSheetBehavior.STATE_HIDDEN) }
+    }
+
+    @Test
+    fun `verify handleNavigationItemClick when non-null view is attached and itemId is search`() {
+        every { view.updateMapInteractionMode(true) } answers { nothing }
+        every { view.displaySearchNotes() } answers { nothing }
+        every { view.updateNavigationState(BottomSheetBehavior.STATE_EXPANDED) } answers { nothing }
+
+        presenter.onAttach(view)
+        val result = presenter.handleNavigationItemClick(searchItemId)
+
+        assertTrue(result)
+        verify { view.updateMapInteractionMode(true) }
+        verify { view.displaySearchNotes() }
+        verify { view.updateNavigationState(BottomSheetBehavior.STATE_EXPANDED) }
+    }
+
+    @Test
+    fun `verify handleNavigationItemClick when non-null view is attached and itemId is incorrect`() {
+        expectedException.expect(IllegalArgumentException::class.java)
+        expectedException.expectMessage("Unknown itemId")
+
+        presenter.onAttach(view)
+        presenter.handleNavigationItemClick(incorrectItemId)
+
+        verify(exactly = 0) { view.updateNavigationState(any()) }
+        verify(exactly = 0) { view.displayAddNote() }
+        verify(exactly = 0) { view.displaySearchNotes() }
+        verify(exactly = 0) { view.updateMapInteractionMode(any()) }
+    }
+
+    // null view
+
+    @Test
+    fun `verify handleNavigationItemClick when null view is attached and itemId is add`() {
+        presenter.onAttach(null)
+        val result = presenter.handleNavigationItemClick(addItemId)
+
+        assertFalse(result)
+        verify(exactly = 0) { view.updateNavigationState(any()) }
+        verify(exactly = 0) { view.displayAddNote() }
+        verify(exactly = 0) { view.displaySearchNotes() }
+        verify(exactly = 0) { view.updateMapInteractionMode(any()) }
+    }
+
+    @Test
+    fun `verify handleNavigationItemClick when null view is attached and itemId is map`() {
+        presenter.onAttach(null)
+        val result = presenter.handleNavigationItemClick(mapItemId)
+
+        assertFalse(result)
+        verify(exactly = 0) { view.updateNavigationState(any()) }
+        verify(exactly = 0) { view.displayAddNote() }
+        verify(exactly = 0) { view.displaySearchNotes() }
+        verify(exactly = 0) { view.updateMapInteractionMode(any()) }
+    }
+
+    @Test
+    fun `verify handleNavigationItemClick when null view is attached and itemId is search`() {
+        presenter.onAttach(null)
+        val result = presenter.handleNavigationItemClick(searchItemId)
+
+        assertFalse(result)
+        verify(exactly = 0) { view.updateNavigationState(any()) }
+        verify(exactly = 0) { view.displayAddNote() }
+        verify(exactly = 0) { view.displaySearchNotes() }
+        verify(exactly = 0) { view.updateMapInteractionMode(any()) }
+    }
+
+    @Test
+    fun `verify handleNavigationItemClick when null view is attached and itemId is incorrect`() {
+        presenter.onAttach(null)
+        val result = presenter.handleNavigationItemClick(incorrectItemId)
+
+        assertFalse(result)
+        verify(exactly = 0) { view.updateNavigationState(any()) }
+        verify(exactly = 0) { view.displayAddNote() }
+        verify(exactly = 0) { view.displaySearchNotes() }
+        verify(exactly = 0) { view.updateMapInteractionMode(any()) }
+    }
+
+    // view is detached
+
+    @Test
+    fun `verify handleNavigationItemClick when view is detached and itemId is add`() {
+        presenter.onAttach(view)
+        presenter.onDetach()
+        val result = presenter.handleNavigationItemClick(addItemId)
+
+        assertFalse(result)
+        verify(exactly = 0) { view.updateNavigationState(any()) }
+        verify(exactly = 0) { view.displayAddNote() }
+        verify(exactly = 0) { view.displaySearchNotes() }
+        verify(exactly = 0) { view.updateMapInteractionMode(any()) }
+    }
+
+    @Test
+    fun `verify handleNavigationItemClick when view is detached and itemId is map`() {
+        presenter.onAttach(view)
+        presenter.onDetach()
+        val result = presenter.handleNavigationItemClick(mapItemId)
+
+        assertFalse(result)
+        verify(exactly = 0) { view.updateNavigationState(any()) }
+        verify(exactly = 0) { view.displayAddNote() }
+        verify(exactly = 0) { view.displaySearchNotes() }
+        verify(exactly = 0) { view.updateMapInteractionMode(any()) }
+    }
+
+    @Test
+    fun `verify handleNavigationItemClick when view is detached and itemId is search`() {
+        presenter.onAttach(view)
+        presenter.onDetach()
+        val result = presenter.handleNavigationItemClick(searchItemId)
+
+        assertFalse(result)
+        verify(exactly = 0) { view.updateNavigationState(any()) }
+        verify(exactly = 0) { view.displayAddNote() }
+        verify(exactly = 0) { view.displaySearchNotes() }
+        verify(exactly = 0) { view.updateMapInteractionMode(any()) }
+    }
+
+    @Test
+    fun `verify handleNavigationItemClick when view is detached and itemId is incorrect`() {
+        presenter.onAttach(view)
+        presenter.onDetach()
+        val result = presenter.handleNavigationItemClick(incorrectItemId)
+
+        assertFalse(result)
+        verify(exactly = 0) { view.updateNavigationState(any()) }
+        verify(exactly = 0) { view.displayAddNote() }
+        verify(exactly = 0) { view.displaySearchNotes() }
+        verify(exactly = 0) { view.updateMapInteractionMode(any()) }
+    }
+
+    @After
+    fun tearDown() = closeKoin()
+}

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext.android_gradle_plugin_version = '3.1.4'
     ext.google_services_gradle_plugin_version = '4.0.0'
-    ext.kotlin_version = '1.2.60'
+    ext.kotlin_version = '1.2.61'
     ext.kotlin_coroutine_version = '0.23.0'
     ext.support_libs_version = '27.1.1'
     ext.constraint_layout_version = '1.1.2'

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ buildscript {
     ext.test_rules_version = '1.0.2'
     ext.espresso_version = '3.0.2'
     ext.uiuatomator_version = '2.1.3'
-    ext.jacoco_core_version = '0.7.9'
-    ext.jacoco_tools_version = '0.8.2-SNAPSHOT'
+    ext.jacoco_core_version = '0.8.2'
+    ext.jacoco_tools_version = '0.8.2'
     ext.ktlint_version = '0.24.0'
 
     repositories {


### PR DESCRIPTION
- Updating AppModule by adding initialisation of HomePresenter
- Updated HomeActivity with KOIN library
- Improved HomePresenter#handleNavigationItemClick, HomePresenter#checkUser and HomePresenter#signOut methods
- Added test cases for the HomeActivity
- Fixed a SignInActivityTest#shouldOpenMapScreenAfterSuccessfulSignIn test case
- Fixed a SignUpActivityTest#shouldOpenMapScreenAfterSuccessfulSignUp test case
- Added BottomNavigationViewMatchers class with list of matchers for verification navigation on HomeActivity using a BottomNavigationView
- Added test cases for the HomePresenter
- Updated Kotlin version to 1.2.61
- Updated JaCoCo-core and JaCoCo-tools to 0.8.2 